### PR TITLE
Make codeVersion a constant in exhibition contract

### DIFF
--- a/contracts/FeralfileArtworkV3.sol
+++ b/contracts/FeralfileArtworkV3.sol
@@ -21,7 +21,7 @@ contract FeralfileExhibitionV3 is ERC721Enumerable, Authorizable, IERC2981 {
     uint256 public constant MAX_ROYALITY_BPS = 100_00;
 
     // version code of contract
-    string public codeVersion;
+    string public constant codeVersion = "FeralfileExhibitionV3";
 
     // burnable
     bool public isBurnable;
@@ -77,7 +77,6 @@ contract FeralfileExhibitionV3 is ERC721Enumerable, Authorizable, IERC2981 {
     constructor(
         string memory name_,
         string memory symbol_,
-        string memory codeVersion_,
         uint256 secondarySaleRoyaltyBPS_,
         address royaltyPayoutAddress_,
         string memory contractURI_,
@@ -94,7 +93,6 @@ contract FeralfileExhibitionV3 is ERC721Enumerable, Authorizable, IERC2981 {
             "invalid royalty payout address"
         );
 
-        codeVersion = codeVersion_;
         secondarySaleRoyaltyBPS = secondarySaleRoyaltyBPS_;
         royaltyPayoutAddress = royaltyPayoutAddress_;
         _contractURI = contractURI_;

--- a/migrations/200_feralfile_exhibition_v3.js
+++ b/migrations/200_feralfile_exhibition_v3.js
@@ -7,7 +7,6 @@ const argv = require('minimist')(process.argv.slice(2), {
 module.exports = function (deployer) {
   let exhibition_name = argv.exhibition_name || 'Feral File V3';
   let exhibition_symbol = argv.exhibition_symbol || 'FFDV2001';
-  let code_version = argv.code_version || 'FeralfileExhibitionV3';
   let exhibition_royalty_payout_address =
     argv.exhibition_royalty_payout_address ||
     '0x2760869A50D48F1C67253C4461c0A6f9e1440Cac';
@@ -20,7 +19,6 @@ module.exports = function (deployer) {
     FeralfileExhibitionV3,
     exhibition_name,
     exhibition_symbol,
-    code_version,
     exhibition_secondary_sale_royalty_bps,
     exhibition_royalty_payout_address,
     'https://ipfs.bitmark.com/ipfs/QmaptARVxNSP36PQai5oiCPqbrATvpydcJ8SPx6T6Yp1CZ',

--- a/test/feralfile_exhibition_v3.js
+++ b/test/feralfile_exhibition_v3.js
@@ -13,7 +13,6 @@ contract('FeralfileExhibitionV3', async (accounts) => {
     this.exhibition = await FeralfileExhibitionV3.new(
       'Feral File V3 Test 001',
       'FFV3',
-      'V3',
       1000,
       '0x8fd310de32848798eB64Bd88f9C5656Eea32415e',
       'https://ipfs.bitmark.com/ipfs/QmaptARVxNSP36PQai5oiCPqbrATvpydcJ8SPx6T6Yp1CZ',


### PR DESCRIPTION
In this PR, we make `codeVersion` be a constant in the contract. In this case, we do not need to enter the value every time since a codeVersion should tidy with a fixed contract code.