### PR TITLE
Add a FFV3_3 for AKG

### DIFF
--- a/contracts/FeralfileArtworkV3_3.sol
+++ b/contracts/FeralfileArtworkV3_3.sol
@@ -1,0 +1,303 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "@openzeppelin/contracts/utils/Strings.sol";
+import "@openzeppelin/contracts/utils/Base64.sol";
+
+import "./Authorizable.sol";
+import "./Decentraland.sol";
+import "./FeralfileArtworkV3_2.sol";
+
+contract FeralfileExhibitionV3_3 is FeralfileExhibitionV3_2 {
+    using Strings for uint256;
+
+    struct ExternalArtworkData {
+        string thumbnailCID;
+        string artworkCID;
+    }
+
+    mapping(uint256 => ExternalArtworkData) public externalArtworkIPFSCID; // artworkID => ExternalArtworkData
+
+    constructor(
+        string memory name_,
+        string memory symbol_,
+        uint256 secondarySaleRoyaltyBPS_,
+        address royaltyPayoutAddress_,
+        string memory contractURI_,
+        string memory tokenBaseURI_,
+        bool isBurnable_,
+        bool isBridgeable_
+    )
+        FeralfileExhibitionV3_2(
+            name_,
+            symbol_,
+            secondarySaleRoyaltyBPS_,
+            royaltyPayoutAddress_,
+            contractURI_,
+            tokenBaseURI_,
+            isBurnable_,
+            isBridgeable_
+        )
+    {}
+
+    address public decentralandAddress =
+        0xF87E31492Faf9A91B02Ee0dEAAd50d51d56D5d4d;
+    uint256 public decentralandTokenID =
+        115792089237316195423570985008687907826047395311965486962387615413371672723439;
+
+    function updateDecentralandInfo(address contractAddress, uint256 tokenId)
+        external
+        onlyOwner
+    {
+        decentralandAddress = contractAddress;
+        decentralandTokenID = tokenId;
+    }
+
+    /// @notice createArtworkWithIPFSCID creates an artwork with a specific
+    /// artwork IPFS CID given.
+    /// @param artwork - the artwork information to be created
+    /// @param thumbnailCID - the thumbnail CID of the external artwork file
+    /// @param artworkCID - the artwork CID of the external artwork file
+    function createArtworkWithIPFSCID(
+        Artwork memory artwork,
+        string memory thumbnailCID,
+        string memory artworkCID
+    ) external onlyAuthorized {
+        require(
+            bytes(thumbnailCID).length != 0,
+            "thumbnail IPFS CID can not be empty"
+        );
+
+        require(
+            bytes(artworkCID).length != 0,
+            "artwork IPFS CID can not be empty"
+        );
+
+        uint256 artworkID = _createArtwork(
+            artwork.fingerprint,
+            artwork.title,
+            artwork.artistName,
+            artwork.editionSize,
+            artwork.AEAmount,
+            artwork.PPAmount
+        );
+
+        externalArtworkIPFSCID[artworkID] = ExternalArtworkData(
+            thumbnailCID,
+            artworkCID
+        );
+    }
+
+    /// @notice createArtworkWithIPFSCID creates an artwork with a specific
+    /// artwork IPFS CID given.
+    /// @param artworkID - the artwork ID for updateing external artwork files
+    /// @param thumbnailCID - the thumbnail CID of the external artwork file
+    /// @param artworkCID - the artwork CID of the external artwork file
+    function updateExternalArtworkIPFSCID(
+        uint256 artworkID,
+        string memory thumbnailCID,
+        string memory artworkCID
+    ) external onlyOwner {
+        /// @notice make sure the artwork has already registered
+        require(
+            bytes(artworks[artworkID].fingerprint).length != 0,
+            "the target artwork is not existent"
+        );
+
+        /// @notice remove external artwork info for an artwork if both
+        /// thumbnailCID and thumbnailCID are empty
+        if (bytes(thumbnailCID).length == 0 && bytes(artworkCID).length == 0) {
+            delete externalArtworkIPFSCID[artworkID];
+            return;
+        }
+
+        externalArtworkIPFSCID[artworkID] = ExternalArtworkData(
+            thumbnailCID,
+            artworkCID
+        );
+    }
+
+    /// @notice tokenEditionNumber returns the edition number of a token
+    function tokenEditionNumber(uint256 tokenID)
+        public
+        view
+        returns (string memory)
+    {
+        ArtworkEditionIndex
+            memory artworkEditionIndex = allArtworkEditionsIndex[tokenID];
+
+        uint256 artworkID = artworkEditionIndex.artworkID;
+
+        Artwork memory artwork = artworks[artworkID];
+        uint256 ppStart = artworkID + artwork.AEAmount;
+        uint256 neStart = artworkID + artwork.AEAmount + artwork.PPAmount;
+
+        if (tokenID < ppStart) {
+            return "AE";
+        } else if (tokenID < neStart) {
+            return "PP";
+        } else {
+            return
+                string(
+                    abi.encodePacked("#", (tokenID - neStart + 1).toString())
+                );
+        }
+    }
+
+    /// @notice buildArtworkData returns an object of artwork which would push to the actually artwork
+    /// @param artworkID - the artwork ID for building artwork data
+    function buildArtworkData(uint256 artworkID)
+        private
+        view
+        returns (string memory)
+    {
+        Decentraland dc = Decentraland(decentralandAddress);
+        uint256[] memory editionIDs = allArtworkEditions[artworkID];
+        bytes memory ownersArray = bytes("[");
+
+        for (uint256 i = 0; i < editionIDs.length; i++) {
+            ownersArray = abi.encodePacked(
+                ownersArray,
+                '"',
+                Strings.toHexString(ownerOf(editionIDs[i])),
+                '",'
+            );
+        }
+
+        ownersArray = abi.encodePacked(ownersArray, "]");
+
+        return
+            string(
+                abi.encodePacked(
+                    "{"
+                    'landOwner:"',
+                    Strings.toHexString(dc.ownerOf(decentralandTokenID)),
+                    '", ownerArray:',
+                    string(ownersArray),
+                    "}"
+                )
+            );
+    }
+
+    /// @notice buildIframe returns a base64 encoded data for ff-frame
+    /// @param artworkData - the artwork data which would bring into the artwork
+    /// @param iframeURI - the artwork URL to loaded into iframe
+    function buildIframe(string memory artworkData, string memory iframeURI)
+        private
+        pure
+        returns (string memory)
+    {
+        return
+            Base64.encode(
+                abi.encodePacked(
+                    '<!DOCTYPE html><html lang="en"><head><script> var defaultArtworkData= ',
+                    artworkData,
+                    "</script><script>"
+                    'let allowOrigins={"https://feralfile.com":!0};function resizeIframe(t){let e=document.getElementById("mainframe");t&&(e.style.minHeight=t+"px")}'
+                    'function initData(){pushArtworkDataToIframe(defaultArtworkData)}function pushArtworkDataToIframe(t){t&&document.getElementById("mainframe").contentWindow.postMessage(t,"*")}'
+                    'function updateArtowrkData(t){document.getElementById("mainframe").contentWindow.postMessage(t,"*")}window.addEventListener("message",function(t){allowOrigins[t.origin]?'
+                    '"update-artwork-data"===t.data.type&&updateArtowrkData(t.data.artworkData):"object"==typeof t.data&&"resize-iframe"===t.data.type&&resizeIframe(t.data.newHeight)});</script>'
+                    '</head><body style="overflow-x:hidden;padding:0;margin:0;width: 100%;" onload="initData()">'
+                    '<iframe id="mainframe" style="display:block;padding:0;margin:0;border:none;width:100%;height:100vh;" src="',
+                    iframeURI,
+                    '"></iframe> </body></html>'
+                )
+            );
+    }
+
+    /// @notice buildDataURL returns a base64 encoded data for ff-frame
+    /// @param artworkID - the artwork ID for building artwork data
+    /// @param tokenID - the token ID for building artwork data
+    /// @param thumbnailCID - the thumbnail ipfs CID for this specific artwork
+    /// @param artworkCID - the artwork ipfs CID for this specific artwork
+    function buildDataURL(
+        uint256 artworkID,
+        uint256 tokenID,
+        string memory thumbnailCID,
+        string memory artworkCID
+    ) private view returns (string memory) {
+        Artwork memory artwork = artworks[artworkID];
+
+        string memory editionNumber = tokenEditionNumber(tokenID);
+        string memory tokenName = string(
+            abi.encodePacked(artwork.title, " ", editionNumber)
+        );
+        return
+            string(
+                abi.encodePacked(
+                    "data:application/json;base64,",
+                    Base64.encode(
+                        // We need to encode twice since the parameters are too many and
+                        // cause the `Stack too deep` error on compilation.
+                        abi.encodePacked(
+                            abi.encodePacked(
+                                '{"id":"',
+                                tokenID.toString(),
+                                '", "name":"',
+                                tokenName,
+                                '", "artist":"',
+                                artwork.artistName,
+                                '", "artwork_id":"',
+                                artworkID.toHexString(),
+                                '", "edition_index":"',
+                                (tokenID - artworkID).toString(),
+                                '", "edition_number":"',
+                                editionNumber
+                            ),
+                            '", "external_url":"https://feralfile.com", "image":"',
+                            buildIPFSURL(thumbnailCID),
+                            '", "animation_url":"data:text/html;base64,',
+                            buildIframe(
+                                buildArtworkData(artworkID),
+                                buildIPFSURL(artworkCID)
+                            ),
+                            '"}'
+                        )
+                    )
+                )
+            );
+    }
+
+    /// @notice buildIPFSURL returns a formatted IPFS link based on the _tokenBaseURI
+    /// @param ipfsCID - thei IPFS Cid
+    function buildIPFSURL(string memory ipfsCID)
+        private
+        view
+        returns (string memory)
+    {
+        string memory baseURI = _tokenBaseURI;
+        if (bytes(baseURI).length == 0) {
+            baseURI = "ipfs://";
+        }
+
+        return string(abi.encodePacked(baseURI, ipfsCID));
+    }
+
+    /// @notice A distinct Uniform Resource Identifier (URI) for a given asset.
+    function tokenURI(uint256 tokenId)
+        public
+        view
+        virtual
+        override
+        returns (string memory)
+    {
+        require(
+            _exists(tokenId),
+            "ERC721Metadata: URI query for nonexistent token"
+        );
+
+        ArtworkEditionIndex
+            memory artworkEditionIndex = allArtworkEditionsIndex[tokenId];
+
+        uint256 artworkID = artworkEditionIndex.artworkID;
+        string memory thumbnailCID = externalArtworkIPFSCID[artworkID]
+            .thumbnailCID;
+        string memory artworkCID = externalArtworkIPFSCID[artworkID].artworkCID;
+
+        if (bytes(artworkCID).length > 0 && bytes(thumbnailCID).length > 0) {
+            return buildDataURL(artworkID, tokenId, thumbnailCID, artworkCID);
+        } else {
+            return buildIPFSURL(artworkEditions[tokenId].ipfsCID);
+        }
+    }
+}

--- a/contracts/FeralfileArtworkV3_3.sol
+++ b/contracts/FeralfileArtworkV3_3.sol
@@ -153,18 +153,20 @@ contract FeralfileExhibitionV3_3 is FeralfileExhibitionV3_2 {
     {
         Decentraland dc = Decentraland(decentralandAddress);
         uint256[] memory editionIDs = allArtworkEditions[artworkID];
-        bytes memory ownersArray = bytes("[");
+        bytes memory ownersMap = bytes("{");
 
         for (uint256 i = 0; i < editionIDs.length; i++) {
-            ownersArray = abi.encodePacked(
-                ownersArray,
-                '"',
-                Strings.toHexString(ownerOf(editionIDs[i])),
+            uint256 tokenID = editionIDs[i];
+            ownersMap = abi.encodePacked(
+                ownersMap,
+                (tokenID - artworkID).toString(),
+                ':"',
+                Strings.toHexString(ownerOf(tokenID)),
                 '",'
             );
         }
 
-        ownersArray = abi.encodePacked(ownersArray, "]");
+        ownersMap = abi.encodePacked(ownersMap, "}");
 
         return
             string(
@@ -172,8 +174,8 @@ contract FeralfileExhibitionV3_3 is FeralfileExhibitionV3_2 {
                     "{"
                     'landOwner:"',
                     Strings.toHexString(dc.ownerOf(decentralandTokenID)),
-                    '", ownerArray:',
-                    string(ownersArray),
+                    '", ownerMap:',
+                    string(ownersMap),
                     "}"
                 )
             );
@@ -193,11 +195,12 @@ contract FeralfileExhibitionV3_3 is FeralfileExhibitionV3_2 {
                     '<!DOCTYPE html><html lang="en"><head><script> var defaultArtworkData= ',
                     artworkData,
                     "</script><script>"
-                    'let allowOrigins={"https://feralfile.com":!0};function resizeIframe(t){let e=document.getElementById("mainframe");t&&(e.style.minHeight=t+"px")}'
-                    'function initData(){pushArtworkDataToIframe(defaultArtworkData)}function pushArtworkDataToIframe(t){t&&document.getElementById("mainframe").contentWindow.postMessage(t,"*")}'
-                    'function updateArtowrkData(t){document.getElementById("mainframe").contentWindow.postMessage(t,"*")}window.addEventListener("message",function(t){allowOrigins[t.origin]?'
-                    '"update-artwork-data"===t.data.type&&updateArtowrkData(t.data.artworkData):"object"==typeof t.data&&"resize-iframe"===t.data.type&&resizeIframe(t.data.newHeight)});</script>'
-                    '</head><body style="overflow-x:hidden;padding:0;margin:0;width: 100%;" onload="initData()">'
+                    'let allowOrigins={"https://feralfile.com":!0};function resizeIframe(e){let t=document.getElementById("mainframe");e&&(t.style.minHeight=e+"px")}'
+                    "function initData(){defaultArtworkData.ownerArray=[];let e=defaultArtworkData.ownerMap;Object.keys(e).sort((e,t)=>e<t).forEach(t=>{defaultArtworkData.ownerArray.push(e[t])}),"
+                    'pushArtworkDataToIframe(defaultArtworkData)}function pushArtworkDataToIframe(e){e&&document.getElementById("mainframe").contentWindow.postMessage(e,"*")}'
+                    'function updateArtowrkData(e){document.getElementById("mainframe").contentWindow.postMessage(e,"*")}window.addEventListener("message",function(e){allowOrigins[e.origin]?'
+                    '"update-artwork-data"===e.data.type&&updateArtowrkData(e.data.artworkData):"object"==typeof e.data&&"resize-iframe"===e.data.type&&resizeIframe(e.data.newHeight)});'
+                    '</script></head><body style="overflow-x:hidden;padding:0;margin:0;width:100%;" onload="initData()">'
                     '<iframe id="mainframe" style="display:block;padding:0;margin:0;border:none;width:100%;height:100vh;" src="',
                     iframeURI,
                     '"></iframe> </body></html>'

--- a/exhibition-metadata/exhibition-fftest.json
+++ b/exhibition-metadata/exhibition-fftest.json
@@ -1,7 +1,7 @@
 {
-  "name": "FFV3 - Test 1",
+  "name": "FFV3_3 - Test 1",
   "description": "Feral File V3 Test Contract",
-  "image": "ipfs://QmV68mphFwMraCE9J6KpQc89Sz8ppvJx5CP6XFruhGQrX8",
+  "image": "https://ipfs.bitmark.com/ipfs/QmekKPW5vphtHLpg1LoHbFBAHeMDTKKNT7yNdakCzCtY7m",
   "external_link": "https://feralfile.com",
   "seller_fee_basis_points": 1000,
   "fee_recipient": "0x2033606bE146405870F92Ea3144ef5057b9DEA48"

--- a/migrations/203_feralfile_exhibition_v3_3.js
+++ b/migrations/203_feralfile_exhibition_v3_3.js
@@ -1,0 +1,29 @@
+var FeralfileExhibitionV3_2 = artifacts.require('FeralfileExhibitionV3_2');
+
+const argv = require('minimist')(process.argv.slice(2), {
+  string: ['exhibition_curator'],
+});
+
+module.exports = function (deployer) {
+  let exhibition_name = argv.exhibition_name || 'FFV3_3 - Test 1';
+  let exhibition_symbol = argv.exhibition_symbol || 'FFDV3_3';
+  let exhibition_royalty_payout_address =
+    argv.exhibition_royalty_payout_address ||
+    '0x2033606bE146405870F92Ea3144ef5057b9DEA48';
+  let exhibition_secondary_sale_royalty_bps =
+    argv.exhibition_secondary_sale_royalty_bps || 1000;
+  let burnable = argv.burnable || true;
+  let bridgeable = argv.bridgeable || true;
+
+  deployer.deploy(
+    FeralfileExhibitionV3_2,
+    exhibition_name,
+    exhibition_symbol,
+    exhibition_secondary_sale_royalty_bps,
+    exhibition_royalty_payout_address,
+    'https://ipfs.bitmark.com/ipfs/QmU1tkyTQ9jb6RaMZMVLZh4W4q9cWeJ3NiNPNw9ruSps6j',
+    'https://ipfs.bitmark.com/ipfs/',
+    burnable,
+    bridgeable
+  );
+};

--- a/test/feralfile_exhibition_v3_3.js
+++ b/test/feralfile_exhibition_v3_3.js
@@ -1,0 +1,151 @@
+const FeralfileExhibitionV3_3 = artifacts.require('FeralfileExhibitionV3_3');
+const MockDecentraland = artifacts.require('MockDecentraland');
+
+const axios = require('axios');
+
+const IPFS_GATEWAY_PREFIX = 'https://ipfs.bitmark.com/ipfs/';
+
+const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
+
+const originArtworkCID = 'QmQPeNsJPyVWPFDVHb77w8G42Fvo15z4bG2X8D2GhfbSXc';
+
+contract('FeralfileExhibitionV3_3', async (accounts) => {
+  before(async function () {
+    this.decentraland = await MockDecentraland.new()
+    this.testThumbnailCid = "QmV68mphFwMraCE9J6KpQc89Sz8ppvJx5CP6XFruhGQrX8" // AKG test IPFS thumbnail CID
+    this.testArtworkCid = "QmTn3PfHHvoDHKawTPXutqxAk2k8ynFK9cZfsSwggryjkX" // AKG test IPFS artwork CID
+
+    this.exhibition = await FeralfileExhibitionV3_3.new(
+      'Feral File V3 Test 002',
+      'FFV3',
+      1000,
+      '0x8fd310de32848798eB64Bd88f9C5656Eea32415e',
+      'https://ipfs.bitmark.com/ipfs/QmaptARVxNSP36PQai5oiCPqbrATvpydcJ8SPx6T6Yp1CZ',
+      IPFS_GATEWAY_PREFIX,
+      true,
+      true
+    );
+
+    this.exhibition.updateDecentralandInfo(this.decentraland.address, 0)
+  });
+
+
+  it('create an artwork with an external IPFS link', async function () {
+    let r = await this.exhibition.createArtworkWithIPFSCID(
+      ['TestArtwork', 'TestUser', 'TestArtwork-fingerprint', 10, 2, 1],
+      this.testThumbnailCid, this.testArtworkCid
+    );
+    this.artworkID = r.logs[0].args.artworkID;
+
+    let artwork = await this.exhibition.artworks(this.artworkID);
+    assert.equal(artwork.title, 'TestArtwork');
+
+    let artworkEditions = await this.exhibition.totalEditionOfArtwork(
+      this.artworkID
+    );
+    assert.equal(artworkEditions, 0);
+
+    let artworkCIDInContract = await this.exhibition.externalArtworkIPFSCID(this.artworkID)
+    assert.equal(this.testThumbnailCid, artworkCIDInContract.thumbnailCID);
+    assert.equal(this.testArtworkCid, artworkCIDInContract.artworkCID);
+  });
+
+  it('test batch mint 4 artworks', async function () {
+    let editionIndex0 = 0;
+    let editionIndex1 = 1;
+    let editionIndex2 = 2;
+    let editionIndex3 = 3;
+    let editionIndex4 = 4;
+
+    await this.exhibition.batchMint([
+      [this.artworkID, editionIndex0, accounts[0], accounts[0], 'test0'],
+      [this.artworkID, editionIndex1, accounts[0], accounts[1], 'test1'],
+      [this.artworkID, editionIndex2, accounts[0], accounts[2], 'test2'],
+      [this.artworkID, editionIndex3, accounts[0], accounts[3], 'test3'],
+      [this.artworkID, editionIndex4, accounts[0], accounts[4], 'test4'],
+    ]);
+
+    let editionID0 = BigInt(this.artworkID) + BigInt(editionIndex0);
+    let ownerOfEdition0 = await this.exhibition.ownerOf(editionID0.toString());
+    assert.equal(ownerOfEdition0.toLowerCase(), accounts[0].toLowerCase());
+    let editionNumber0 = await this.exhibition.tokenEditionNumber(editionID0.toString());
+    assert.equal(editionNumber0, "AE");
+
+    let editionID1 = BigInt(this.artworkID) + BigInt(editionIndex1);
+    let ownerOfEdition1 = await this.exhibition.ownerOf(editionID1.toString());
+    assert.equal(ownerOfEdition1.toLowerCase(), accounts[1].toLowerCase());
+    let editionNumber1 = await this.exhibition.tokenEditionNumber(editionID1.toString());
+    assert.equal(editionNumber1, "AE");
+
+    let editionID2 = BigInt(this.artworkID) + BigInt(editionIndex2);
+    let ownerOfEdition2 = await this.exhibition.ownerOf(editionID2.toString());
+    assert.equal(ownerOfEdition2.toLowerCase(), accounts[2].toLowerCase());
+    let editionNumber2 = await this.exhibition.tokenEditionNumber(editionID2.toString());
+    assert.equal(editionNumber2, "PP");
+
+    let editionID3 = BigInt(this.artworkID) + BigInt(editionIndex3);
+    let ownerOfEdition3 = await this.exhibition.ownerOf(editionID3.toString());
+    assert.equal(ownerOfEdition3.toLowerCase(), accounts[3].toLowerCase());
+    let editionNumber3 = await this.exhibition.tokenEditionNumber(editionID3.toString());
+    assert.equal(editionNumber3, "#1");
+
+    let editionID4 = BigInt(this.artworkID) + BigInt(editionIndex4);
+    let ownerOfEdition4 = await this.exhibition.ownerOf(editionID4.toString());
+    assert.equal(ownerOfEdition4.toLowerCase(), accounts[4].toLowerCase());
+    let editionNumber4 = await this.exhibition.tokenEditionNumber(editionID4.toString());
+    assert.equal(editionNumber4, "#2");
+  })
+
+  it('test build metadata for artwork with IPFS', async function () {
+    let editionNumber1 = 1;
+
+    // let expectedMetadata = "data:application/json;base64,eyJpZCI6IjMyNzkxMjY5MzU4MDE5MTk0ODk2MzMwMTk1MjYzMzIyNzUyNTY2ODM2MTkzMjE4MzY5MzU2NTAxODc5MTA0MjI4MjI4NzcxNzAwNjEwIiwgIm5hbWUiOiJUZXN0QXJ0d29yayBBRSIsICJhcnRpc3QiOiJUZXN0VXNlciIsICJhcnR3b3JrX2lkIjoiMHg0ODdmMzM2M2VhODc1ODMyODU3NGE4ODI5NDM0OTNkNGFkOTQ3YWVkYzgwZjc3MTgwY2M3NmZhMGQyZmQ1ZjgxIiwgImVkaXRpb25faW5kZXgiOiIxIiwgImVkaXRpb25fbnVtYmVyIjoiQUUiLCAiZXh0ZXJuYWxfdXJsIjoiaHR0cHM6Ly9mZXJhbGZpbGUuY29tIiwgImltYWdlIjoiaHR0cHM6Ly9pcGZzLmJpdG1hcmsuY29tL2lwZnMvUW1hcU03UnlwQm9ISlp5dU53c01OUTdlN3ZVTXlHWHV4SHJBbXJzNGtoUFl5eiIsICJhbmltYXRpb25fdXJsIjoiZGF0YTp0ZXh0L2h0bWw7YmFzZTY0LFBDRkVUME5VV1ZCRklHaDBiV3crUEdoMGJXd2diR0Z1WnowaVpXNGlQanhvWldGa1BqeHpZM0pwY0hRK0lIWmhjaUJrWldaaGRXeDBRWEowZDI5eWEwUmhkR0U5SUh0c1lXNWtUM2R1WlhJNklqQjRNREUzTjJKaE1tRmtNRFZqWWpFeVpEWmtaRFl6TnprMk0yVXdOREF3T1RJMk56WmxaVGhrWlNJc0lHOTNibVZ5UVhKeVlYazZXeUl3ZUdJMU5UWXhNMk0xWWpBNU9UaGxOREptTWpNNU1UVmtORFJqTWpReE1EYzBOR00xTTJFeFlUUWlMQ0l3ZUdWa05EZGtOREF6WldRd1lqaGxOak13WlRrNU1EQXpaRFptWkdNMU5ESTNZVFZtTnpFM05tSWlMQ0l3ZUdZM05UWmpaVEJrTVRkbVpETTBNekk0T0RRM09HVmxNak5sTXpaaVkyTXdObU13WkdNME9USWlMQ0l3ZUdJeVpXVmhaREF6WWpZNVl6UXpaREUyWlRaaU1XUXhORGxpTlRjNFl6VTNNVFV3WmpjeE1UUWlMQ0l3ZUdKa05qRTNPR1V3TUdZeE9EUmhNalkyT1RNeE5tUmhaRE5oTlRoaE56ZzBNVE5sWmpSa01EY2lMRjE5UEM5elkzSnBjSFErUEhOamNtbHdkRDVzWlhRZ1lXeHNiM2RQY21sbmFXNXpQWHNpYUhSMGNITTZMeTltWlhKaGJHWnBiR1V1WTI5dElqb2hNSDA3Wm5WdVkzUnBiMjRnY21WemFYcGxTV1p5WVcxbEtIUXBlMnhsZENCbFBXUnZZM1Z0Wlc1MExtZGxkRVZzWlcxbGJuUkNlVWxrS0NKdFlXbHVabkpoYldVaUtUdDBKaVlvWlM1emRIbHNaUzV0YVc1SVpXbG5hSFE5ZENzaWNIZ2lMR1V1YzNSNWJHVXVhR1ZwWjJoMFBYUXJJbkI0SWlsOVpuVnVZM1JwYjI0Z2FXNXBkRVJoZEdFb0tYdHdkWE5vUVhKMGQyOXlhMFJoZEdGVWIwbG1jbUZ0WlNoa1pXWmhkV3gwUVhKMGQyOXlhMFJoZEdFcGZXWjFibU4wYVc5dUlIQjFjMmhCY25SM2IzSnJSR0YwWVZSdlNXWnlZVzFsS0hRcGUzUW1KbVJ2WTNWdFpXNTBMbWRsZEVWc1pXMWxiblJDZVVsa0tDSnRZV2x1Wm5KaGJXVWlLUzVqYjI1MFpXNTBWMmx1Wkc5M0xuQnZjM1JOWlhOellXZGxLSFFzSWlvaUtYMW1kVzVqZEdsdmJpQjFjR1JoZEdWQmNuUnZkM0pyUkdGMFlTaDBLWHRrYjJOMWJXVnVkQzVuWlhSRmJHVnRaVzUwUW5sSlpDZ2liV0ZwYm1aeVlXMWxJaWt1WTI5dWRHVnVkRmRwYm1SdmR5NXdiM04wVFdWemMyRm5aU2gwTENJcUlpbDlkMmx1Wkc5M0xtRmtaRVYyWlc1MFRHbHpkR1Z1WlhJb0ltMWxjM05oWjJVaUxHWjFibU4wYVc5dUtIUXBlMkZzYkc5M1QzSnBaMmx1YzF0MExtOXlhV2RwYmwwL0luVndaR0YwWlMxaGNuUjNiM0pyTFdSaGRHRWlQVDA5ZEM1a1lYUmhMblI1Y0dVbUpuVndaR0YwWlVGeWRHOTNjbXRFWVhSaEtIUXVaR0YwWVM1aGNuUjNiM0pyUkdGMFlTazZJbTlpYW1WamRDSTlQWFI1Y0dWdlppQjBMbVJoZEdFbUppSnlaWE5wZW1VdGFXWnlZVzFsSWowOVBYUXVaR0YwWVM1MGVYQmxKaVp5WlhOcGVtVkpabkpoYldVb2RDNWtZWFJoTG01bGQwaGxhV2RvZENsOUtUczhMM05qY21sd2RENDhMMmhsWVdRK1BHSnZaSGtnYzNSNWJHVTlJbTkyWlhKbWJHOTNMWGc2SUdocFpHUmxianNnY0dGa1pHbHVaem9nTURzZ2JXRnlaMmx1T2lBd095QjNhV1IwYURvZ01UQXdKVHNpSUc5dWJHOWhaRDBpYVc1cGRFUmhkR0VvS1NJK1BHbG1jbUZ0WlNCcFpEMGliV0ZwYm1aeVlXMWxJaUJ6ZEhsc1pUMGlaR2x6Y0d4aGVUcGliRzlqYXpzZ2NHRmtaR2x1WnpvZ01Ec2diV0Z5WjJsdU9pQXdPeUJpYjNKa1pYSTZibTl1WlRzZ2QybGtkR2c2SURFd01DVTdJaUJ6Y21NOUltaDBkSEJ6T2k4dmFYQm1jeTVpYVhSdFlYSnJMbU52YlM5cGNHWnpMMUZ0WVhGTk4xSjVjRUp2U0VwYWVYVk9kM05OVGxFM1pUZDJWVTE1UjFoMWVFaHlRVzF5Y3pScmFGQlplWG9pUGp3dmFXWnlZVzFsUGlBOEwySnZaSGsrUEM5b2RHMXNQZz09In0="
+
+    let tokenURI = await this.exhibition.tokenURI(BigInt(this.artworkID) + BigInt(editionNumber1))
+    assert.equal(tokenURI.startsWith("data:application/json;base64,"), true);
+
+    const metadataJSON = JSON.parse(Buffer.from(tokenURI.replace("data:application/json;base64,", ""), "base64").toString());
+    assert.equal(metadataJSON.image, "https://ipfs.bitmark.com/ipfs/" + this.testThumbnailCid);
+    // TODO: use regular expression to validate the html data
+    assert.equal(metadataJSON.animation_url, "data:text/html;base64,PCFET0NUWVBFIGh0bWw+PGh0bWwgbGFuZz0iZW4iPjxoZWFkPjxzY3JpcHQ+IHZhciBkZWZhdWx0QXJ0d29ya0RhdGE9IHtsYW5kT3duZXI6IjB4MDE3N2JhMmFkMDVjYjEyZDZkZDYzNzk2M2UwNDAwOTI2NzZlZThkZSIsIG93bmVyQXJyYXk6WyIweGRhMTQ5NWNhNmNhZGI1ODFjNDI0YTI2NTVmNDM3M2RiYzBiMDJhMmEiLCIweDJkYjVhM2Q2MDNmZTdmNDNiMzBjZTA5MDg1NWMxMTJmYTIyMjE2ODciLCIweDQ0NGQxOGY3NmVjMDkzN2ZmMmE4M2MzMTI4OTFhYjg1M2E3MTkxZDMiLCIweDNkYjFlOTg4MzU2OWY0MjllOGViZmNmZDBhZmMyYzIyOGFmNDQxZGQiLCIweDVmZWQ0MzFhOWY4MzRmN2QyMzk1N2ZmZGE0NWMwNTFmOTQ0YjE3YjQiLF19PC9zY3JpcHQ+PHNjcmlwdD5sZXQgYWxsb3dPcmlnaW5zPXsiaHR0cHM6Ly9mZXJhbGZpbGUuY29tIjohMH07ZnVuY3Rpb24gcmVzaXplSWZyYW1lKHQpe2xldCBlPWRvY3VtZW50LmdldEVsZW1lbnRCeUlkKCJtYWluZnJhbWUiKTt0JiYoZS5zdHlsZS5taW5IZWlnaHQ9dCsicHgiKX1mdW5jdGlvbiBpbml0RGF0YSgpe3B1c2hBcnR3b3JrRGF0YVRvSWZyYW1lKGRlZmF1bHRBcnR3b3JrRGF0YSl9ZnVuY3Rpb24gcHVzaEFydHdvcmtEYXRhVG9JZnJhbWUodCl7dCYmZG9jdW1lbnQuZ2V0RWxlbWVudEJ5SWQoIm1haW5mcmFtZSIpLmNvbnRlbnRXaW5kb3cucG9zdE1lc3NhZ2UodCwiKiIpfWZ1bmN0aW9uIHVwZGF0ZUFydG93cmtEYXRhKHQpe2RvY3VtZW50LmdldEVsZW1lbnRCeUlkKCJtYWluZnJhbWUiKS5jb250ZW50V2luZG93LnBvc3RNZXNzYWdlKHQsIioiKX13aW5kb3cuYWRkRXZlbnRMaXN0ZW5lcigibWVzc2FnZSIsZnVuY3Rpb24odCl7YWxsb3dPcmlnaW5zW3Qub3JpZ2luXT8idXBkYXRlLWFydHdvcmstZGF0YSI9PT10LmRhdGEudHlwZSYmdXBkYXRlQXJ0b3dya0RhdGEodC5kYXRhLmFydHdvcmtEYXRhKToib2JqZWN0Ij09dHlwZW9mIHQuZGF0YSYmInJlc2l6ZS1pZnJhbWUiPT09dC5kYXRhLnR5cGUmJnJlc2l6ZUlmcmFtZSh0LmRhdGEubmV3SGVpZ2h0KX0pOzwvc2NyaXB0PjwvaGVhZD48Ym9keSBzdHlsZT0ib3ZlcmZsb3cteDpoaWRkZW47cGFkZGluZzowO21hcmdpbjowO3dpZHRoOiAxMDAlOyIgb25sb2FkPSJpbml0RGF0YSgpIj48aWZyYW1lIGlkPSJtYWluZnJhbWUiIHN0eWxlPSJkaXNwbGF5OmJsb2NrO3BhZGRpbmc6MDttYXJnaW46MDtib3JkZXI6bm9uZTt3aWR0aDoxMDAlO2hlaWdodDoxMDB2aDsiIHNyYz0iaHR0cHM6Ly9pcGZzLmJpdG1hcmsuY29tL2lwZnMvUW1UbjNQZkhIdm9ESEthd1RQWHV0cXhBazJrOHluRks5Y1pmc1N3Z2dyeWprWCI+PC9pZnJhbWU+IDwvYm9keT48L2h0bWw+");
+  })
+
+  it('test update artwork external file CIDs', async function () {
+    let newCid = "QmV68mphFwMraCE9J6KpQc89Sz8ppvJx5CP6XFruhGQrX8"
+
+    await this.exhibition.updateExternalArtworkIPFSCID(this.artworkID, newCid, newCid)
+    let artworkCIDInContract = await this.exhibition.externalArtworkIPFSCID(this.artworkID)
+    assert.equal(newCid, artworkCIDInContract.thumbnailCID);
+    assert.equal(newCid, artworkCIDInContract.artworkCID);
+  })
+
+  it('test remove artwork external file CIDs by using with empty CID', async function () {
+    let newCid = ""
+    let editionNumber1 = 1
+
+    await this.exhibition.updateExternalArtworkIPFSCID(this.artworkID, newCid, newCid)
+    let artworkCIDInContract = await this.exhibition.externalArtworkIPFSCID(this.artworkID)
+    assert.equal(newCid, artworkCIDInContract.thumbnailCID);
+    assert.equal(newCid, artworkCIDInContract.artworkCID);
+
+    let tokenURI = await this.exhibition.tokenURI(BigInt(this.artworkID) + BigInt(editionNumber1))
+    console.log(tokenURI)
+    assert.equal(tokenURI.startsWith("https://ipfs.bitmark.com/ipfs/"), true);
+  })
+
+  it('test update artwork external file CIDs with non exist artwork ID', async function () {
+    let newCid = ""
+    let error
+
+    try {
+      await this.exhibition.updateExternalArtworkIPFSCID("0x0123", newCid, newCid)
+    } catch (e) {
+      error = e
+    }
+
+    assert.equal(
+      error.message,
+      'Returned error: VM Exception while processing transaction: revert the target artwork is not existent'
+    );
+  })
+});

--- a/test/feralfile_exhibition_v3_3.js
+++ b/test/feralfile_exhibition_v3_3.js
@@ -13,7 +13,7 @@ contract('FeralfileExhibitionV3_3', async (accounts) => {
   before(async function () {
     this.decentraland = await MockDecentraland.new()
     this.testThumbnailCid = "QmV68mphFwMraCE9J6KpQc89Sz8ppvJx5CP6XFruhGQrX8" // AKG test IPFS thumbnail CID
-    this.testArtworkCid = "QmTn3PfHHvoDHKawTPXutqxAk2k8ynFK9cZfsSwggryjkX" // AKG test IPFS artwork CID
+    this.testArtworkCid = "QmXsDVEszo4XzyVK3UF8mKzUNfaUT3fpXwarca6VmGPwvq" // AKG test IPFS artwork CID
 
     this.exhibition = await FeralfileExhibitionV3_3.new(
       'Feral File V3 Test 002',
@@ -61,8 +61,8 @@ contract('FeralfileExhibitionV3_3', async (accounts) => {
       [this.artworkID, editionIndex0, accounts[0], accounts[0], 'test0'],
       [this.artworkID, editionIndex1, accounts[0], accounts[1], 'test1'],
       [this.artworkID, editionIndex2, accounts[0], accounts[2], 'test2'],
-      [this.artworkID, editionIndex3, accounts[0], accounts[3], 'test3'],
-      [this.artworkID, editionIndex4, accounts[0], accounts[4], 'test4'],
+      [this.artworkID, editionIndex3, accounts[0], accounts[2], 'test3'],
+      [this.artworkID, editionIndex4, accounts[0], accounts[3], 'test4'],
     ]);
 
     let editionID0 = BigInt(this.artworkID) + BigInt(editionIndex0);
@@ -85,13 +85,13 @@ contract('FeralfileExhibitionV3_3', async (accounts) => {
 
     let editionID3 = BigInt(this.artworkID) + BigInt(editionIndex3);
     let ownerOfEdition3 = await this.exhibition.ownerOf(editionID3.toString());
-    assert.equal(ownerOfEdition3.toLowerCase(), accounts[3].toLowerCase());
+    assert.equal(ownerOfEdition3.toLowerCase(), accounts[2].toLowerCase());
     let editionNumber3 = await this.exhibition.tokenEditionNumber(editionID3.toString());
     assert.equal(editionNumber3, "#1");
 
     let editionID4 = BigInt(this.artworkID) + BigInt(editionIndex4);
     let ownerOfEdition4 = await this.exhibition.ownerOf(editionID4.toString());
-    assert.equal(ownerOfEdition4.toLowerCase(), accounts[4].toLowerCase());
+    assert.equal(ownerOfEdition4.toLowerCase(), accounts[3].toLowerCase());
     let editionNumber4 = await this.exhibition.tokenEditionNumber(editionID4.toString());
     assert.equal(editionNumber4, "#2");
   })
@@ -107,7 +107,8 @@ contract('FeralfileExhibitionV3_3', async (accounts) => {
     const metadataJSON = JSON.parse(Buffer.from(tokenURI.replace("data:application/json;base64,", ""), "base64").toString());
     assert.equal(metadataJSON.image, "https://ipfs.bitmark.com/ipfs/" + this.testThumbnailCid);
     // TODO: use regular expression to validate the html data
-    assert.equal(metadataJSON.animation_url, "data:text/html;base64,PCFET0NUWVBFIGh0bWw+PGh0bWwgbGFuZz0iZW4iPjxoZWFkPjxzY3JpcHQ+IHZhciBkZWZhdWx0QXJ0d29ya0RhdGE9IHtsYW5kT3duZXI6IjB4MDE3N2JhMmFkMDVjYjEyZDZkZDYzNzk2M2UwNDAwOTI2NzZlZThkZSIsIG93bmVyQXJyYXk6WyIweGRhMTQ5NWNhNmNhZGI1ODFjNDI0YTI2NTVmNDM3M2RiYzBiMDJhMmEiLCIweDJkYjVhM2Q2MDNmZTdmNDNiMzBjZTA5MDg1NWMxMTJmYTIyMjE2ODciLCIweDQ0NGQxOGY3NmVjMDkzN2ZmMmE4M2MzMTI4OTFhYjg1M2E3MTkxZDMiLCIweDNkYjFlOTg4MzU2OWY0MjllOGViZmNmZDBhZmMyYzIyOGFmNDQxZGQiLCIweDVmZWQ0MzFhOWY4MzRmN2QyMzk1N2ZmZGE0NWMwNTFmOTQ0YjE3YjQiLF19PC9zY3JpcHQ+PHNjcmlwdD5sZXQgYWxsb3dPcmlnaW5zPXsiaHR0cHM6Ly9mZXJhbGZpbGUuY29tIjohMH07ZnVuY3Rpb24gcmVzaXplSWZyYW1lKHQpe2xldCBlPWRvY3VtZW50LmdldEVsZW1lbnRCeUlkKCJtYWluZnJhbWUiKTt0JiYoZS5zdHlsZS5taW5IZWlnaHQ9dCsicHgiKX1mdW5jdGlvbiBpbml0RGF0YSgpe3B1c2hBcnR3b3JrRGF0YVRvSWZyYW1lKGRlZmF1bHRBcnR3b3JrRGF0YSl9ZnVuY3Rpb24gcHVzaEFydHdvcmtEYXRhVG9JZnJhbWUodCl7dCYmZG9jdW1lbnQuZ2V0RWxlbWVudEJ5SWQoIm1haW5mcmFtZSIpLmNvbnRlbnRXaW5kb3cucG9zdE1lc3NhZ2UodCwiKiIpfWZ1bmN0aW9uIHVwZGF0ZUFydG93cmtEYXRhKHQpe2RvY3VtZW50LmdldEVsZW1lbnRCeUlkKCJtYWluZnJhbWUiKS5jb250ZW50V2luZG93LnBvc3RNZXNzYWdlKHQsIioiKX13aW5kb3cuYWRkRXZlbnRMaXN0ZW5lcigibWVzc2FnZSIsZnVuY3Rpb24odCl7YWxsb3dPcmlnaW5zW3Qub3JpZ2luXT8idXBkYXRlLWFydHdvcmstZGF0YSI9PT10LmRhdGEudHlwZSYmdXBkYXRlQXJ0b3dya0RhdGEodC5kYXRhLmFydHdvcmtEYXRhKToib2JqZWN0Ij09dHlwZW9mIHQuZGF0YSYmInJlc2l6ZS1pZnJhbWUiPT09dC5kYXRhLnR5cGUmJnJlc2l6ZUlmcmFtZSh0LmRhdGEubmV3SGVpZ2h0KX0pOzwvc2NyaXB0PjwvaGVhZD48Ym9keSBzdHlsZT0ib3ZlcmZsb3cteDpoaWRkZW47cGFkZGluZzowO21hcmdpbjowO3dpZHRoOiAxMDAlOyIgb25sb2FkPSJpbml0RGF0YSgpIj48aWZyYW1lIGlkPSJtYWluZnJhbWUiIHN0eWxlPSJkaXNwbGF5OmJsb2NrO3BhZGRpbmc6MDttYXJnaW46MDtib3JkZXI6bm9uZTt3aWR0aDoxMDAlO2hlaWdodDoxMDB2aDsiIHNyYz0iaHR0cHM6Ly9pcGZzLmJpdG1hcmsuY29tL2lwZnMvUW1UbjNQZkhIdm9ESEthd1RQWHV0cXhBazJrOHluRks5Y1pmc1N3Z2dyeWprWCI+PC9pZnJhbWU+IDwvYm9keT48L2h0bWw+");
+    // This test case now will be broken when ganache restarted (the account changes).
+    assert.equal(metadataJSON.animation_url, "data:text/html;base64,PCFET0NUWVBFIGh0bWw+PGh0bWwgbGFuZz0iZW4iPjxoZWFkPjxzY3JpcHQ+IHZhciBkZWZhdWx0QXJ0d29ya0RhdGE9IHtsYW5kT3duZXI6IjB4MDE3N2JhMmFkMDVjYjEyZDZkZDYzNzk2M2UwNDAwOTI2NzZlZThkZSIsIG93bmVyTWFwOnswOiIweDQzMTJmOGNkMTcxYmRkNTdkY2U4NWJjNGJmNzE5MTYxODJiZmIzM2UiLDE6IjB4YjI3Nzc3NWJkMzI2NzA2MzZhMTFjMDZlMmY2ZGQ3ZjZiNjVmMDdjYiIsMjoiMHgxMjZhYmUwMzNkYmNlNGU1YWQ3ZTU4OWY2MmExMmJjNDk5ZjNmMTBhIiwzOiIweDEyNmFiZTAzM2RiY2U0ZTVhZDdlNTg5ZjYyYTEyYmM0OTlmM2YxMGEiLDQ6IjB4MzlhYzExYTM1ODFjZmIzMDYxMzYzOTY3ZDI3NDZmNzBiNjhlNDI3ZiIsfX08L3NjcmlwdD48c2NyaXB0PmxldCBhbGxvd09yaWdpbnM9eyJodHRwczovL2ZlcmFsZmlsZS5jb20iOiEwfTtmdW5jdGlvbiByZXNpemVJZnJhbWUoZSl7bGV0IHQ9ZG9jdW1lbnQuZ2V0RWxlbWVudEJ5SWQoIm1haW5mcmFtZSIpO2UmJih0LnN0eWxlLm1pbkhlaWdodD1lKyJweCIpfWZ1bmN0aW9uIGluaXREYXRhKCl7ZGVmYXVsdEFydHdvcmtEYXRhLm93bmVyQXJyYXk9W107bGV0IGU9ZGVmYXVsdEFydHdvcmtEYXRhLm93bmVyTWFwO09iamVjdC5rZXlzKGUpLnNvcnQoKGUsdCk9PmU8dCkuZm9yRWFjaCh0PT57ZGVmYXVsdEFydHdvcmtEYXRhLm93bmVyQXJyYXkucHVzaChlW3RdKX0pLHB1c2hBcnR3b3JrRGF0YVRvSWZyYW1lKGRlZmF1bHRBcnR3b3JrRGF0YSl9ZnVuY3Rpb24gcHVzaEFydHdvcmtEYXRhVG9JZnJhbWUoZSl7ZSYmZG9jdW1lbnQuZ2V0RWxlbWVudEJ5SWQoIm1haW5mcmFtZSIpLmNvbnRlbnRXaW5kb3cucG9zdE1lc3NhZ2UoZSwiKiIpfWZ1bmN0aW9uIHVwZGF0ZUFydG93cmtEYXRhKGUpe2RvY3VtZW50LmdldEVsZW1lbnRCeUlkKCJtYWluZnJhbWUiKS5jb250ZW50V2luZG93LnBvc3RNZXNzYWdlKGUsIioiKX13aW5kb3cuYWRkRXZlbnRMaXN0ZW5lcigibWVzc2FnZSIsZnVuY3Rpb24oZSl7YWxsb3dPcmlnaW5zW2Uub3JpZ2luXT8idXBkYXRlLWFydHdvcmstZGF0YSI9PT1lLmRhdGEudHlwZSYmdXBkYXRlQXJ0b3dya0RhdGEoZS5kYXRhLmFydHdvcmtEYXRhKToib2JqZWN0Ij09dHlwZW9mIGUuZGF0YSYmInJlc2l6ZS1pZnJhbWUiPT09ZS5kYXRhLnR5cGUmJnJlc2l6ZUlmcmFtZShlLmRhdGEubmV3SGVpZ2h0KX0pOzwvc2NyaXB0PjwvaGVhZD48Ym9keSBzdHlsZT0ib3ZlcmZsb3cteDpoaWRkZW47cGFkZGluZzowO21hcmdpbjowO3dpZHRoOjEwMCU7IiBvbmxvYWQ9ImluaXREYXRhKCkiPjxpZnJhbWUgaWQ9Im1haW5mcmFtZSIgc3R5bGU9ImRpc3BsYXk6YmxvY2s7cGFkZGluZzowO21hcmdpbjowO2JvcmRlcjpub25lO3dpZHRoOjEwMCU7aGVpZ2h0OjEwMHZoOyIgc3JjPSJodHRwczovL2lwZnMuYml0bWFyay5jb20vaXBmcy9RbVhzRFZFc3pvNFh6eVZLM1VGOG1LelVOZmFVVDNmcFh3YXJjYTZWbUdQd3ZxIj48L2lmcmFtZT4gPC9ib2R5PjwvaHRtbD4=");
   })
 
   it('test update artwork external file CIDs', async function () {

--- a/test/feralfile_exhibition_v3_3_regression_v3.js
+++ b/test/feralfile_exhibition_v3_3_regression_v3.js
@@ -1,0 +1,401 @@
+const FeralfileExhibitionV3_3 = artifacts.require('FeralfileExhibitionV3_3');
+
+const axios = require('axios');
+
+const IPFS_GATEWAY_PREFIX = 'https://cloudflare-ipfs.com/ipfs/';
+
+const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
+
+const originArtworkCID = 'QmQPeNsJPyVWPFDVHb77w8G42Fvo15z4bG2X8D2GhfbSXc';
+
+contract('FeralfileExhibitionV3_3->V3_regression', async (accounts) => {
+  before(async function () {
+    this.exhibition = await FeralfileExhibitionV3_3.new(
+      'Feral File V3 Test 001',
+      'FFV3',
+      1000,
+      '0x8fd310de32848798eB64Bd88f9C5656Eea32415e',
+      'https://ipfs.bitmark.com/ipfs/QmaptARVxNSP36PQai5oiCPqbrATvpydcJ8SPx6T6Yp1CZ',
+      IPFS_GATEWAY_PREFIX,
+      true,
+      true
+    );
+  });
+
+  it('check contract is burnable', async function () {
+    let isBurnable = await this.exhibition.isBurnable();
+    assert.equal(isBurnable, true);
+  });
+
+  it('check contract is bridgeable', async function () {
+    let isBridgeable = await this.exhibition.isBridgeable();
+    assert.equal(isBridgeable, true);
+  });
+
+  it('create an artwork correctly with no editions on it', async function () {
+    let r = await this.exhibition.createArtworks([
+      ['TestArtwork', 'TestUser', 'TestArtwork', 10, 2, 1],
+    ]);
+    this.artworkID = r.logs[0].args.artworkID;
+
+    let artwork = await this.exhibition.artworks(this.artworkID);
+    assert.equal(artwork.title, 'TestArtwork');
+
+    let artworkEditions = await this.exhibition.totalEditionOfArtwork(
+      this.artworkID
+    );
+    assert.equal(artworkEditions, 0);
+  });
+
+  it('fail to create an artwork with duplicated fingerprint', async function () {
+    try {
+      let r = await this.exhibition.createArtworks([
+        ['TestArtwork', 'TestUser', 'TestArtwork', 5, 2, 1],
+      ]);
+    } catch (error) {
+      console.log(error.message);
+
+      assert.equal(
+        error.message,
+        'Returned error: VM Exception while processing transaction: revert an artwork with the same fingerprint has already registered'
+      );
+    }
+  });
+
+  it('fail to create an artwork with empty fingerprint', async function () {
+    try {
+      let r = await this.exhibition.createArtworks([
+        ['TestArtwork', 'TestUser', '', 10, 2, 1],
+      ]);
+    } catch (error) {
+      console.log(error.message);
+
+      assert.equal(
+        error.message,
+        'Returned error: VM Exception while processing transaction: revert fingerprint can not be empty'
+      );
+    }
+  });
+
+  it('fail to create an artwork with empty title', async function () {
+    try {
+      let r = await this.exhibition.createArtworks([
+        ['', 'TestUser', 'TestArtwork', 5, 2, 1],
+      ]);
+    } catch (error) {
+      console.log(error.message);
+
+      assert.equal(
+        error.message,
+        'Returned error: VM Exception while processing transaction: revert title can not be empty'
+      );
+    }
+  });
+
+  it('fail to create an artwork with empty artist name', async function () {
+    try {
+      let r = await this.exhibition.createArtworks([
+        ['TestArtwork', '', 'TestArtwork', 5, 2, 1],
+      ]);
+    } catch (error) {
+      console.log(error.message);
+
+      assert.equal(
+        error.message,
+        'Returned error: VM Exception while processing transaction: revert artist can not be empty'
+      );
+    }
+  });
+
+  it('fail to create an artwork with empty edition size', async function () {
+    try {
+      let r = await this.exhibition.createArtworks([
+        ['TestArtwork', 'TestArtwork', 'TestArtwork', 0, 2, 1],
+      ]);
+    } catch (error) {
+      console.log(error.message);
+
+      assert.equal(
+        error.message,
+        'Returned error: VM Exception while processing transaction: revert edition size needs to be at least 1'
+      );
+    }
+  });
+
+  it('can update the IPFS to a new one', async function () {
+    let newCID = 'QmQPeNsJPyVWPFDVHb77w8G42Fvo15z4bG2X8D2GhfbSXcNew';
+
+    let testEditionNumber = 1;
+    let editionID = BigInt(this.artworkID) + BigInt(testEditionNumber);
+    await this.exhibition.batchMint([
+      [
+        this.artworkID,
+        testEditionNumber,
+        '0xb824edfc5dced3ac86b6f5816763a35c2ba66fa2',
+        accounts[1],
+        'test',
+      ],
+    ]);
+    await this.exhibition.updateArtworkEditionIPFSCid(editionID, newCID);
+
+    let artworkEdition = await this.exhibition.artworkEditions(editionID);
+
+    assert.equal(artworkEdition.ipfsCID, newCID);
+  });
+
+  it('cannot update the IPFS cid using an existent IPFS cid', async function () {
+    let testEditionNumber = 1;
+    let editionID = BigInt(this.artworkID) + BigInt(testEditionNumber);
+    try {
+      await this.exhibition.updateArtworkEditionIPFSCid(
+        editionID,
+        originArtworkCID
+      );
+    } catch (error) {
+      assert.equal(
+        error.message,
+        'Returned error: VM Exception while processing transaction: revert artwork edition is not found'
+      );
+    }
+  });
+
+  it('cannot update the IPFS cid for a non-existent token', async function () {
+    let newCID = 'QmQPeNsJPyVWPFDVHb77w8G42Fvo15z4bG2X8D2GhfbSXcNew';
+
+    let editionID = 1;
+    try {
+      await this.exhibition.updateArtworkEditionIPFSCid(editionID, newCID);
+    } catch (error) {
+      assert.equal(
+        error.message,
+        'Returned error: VM Exception while processing transaction: revert artwork edition is not found'
+      );
+    }
+  });
+
+  it('can not set royalty payout address to zero address', async function () {
+    try {
+      await this.exhibition.setRoyaltyPayoutAddress(ZERO_ADDRESS);
+    } catch (error) {
+      assert.equal(
+        error.message,
+        'Returned error: VM Exception while processing transaction: revert invalid royalty payout address'
+      );
+    }
+  });
+
+  it('can not set royalty payout address to zero address', async function () {
+    try {
+      await this.exhibition.setRoyaltyPayoutAddress(ZERO_ADDRESS);
+    } catch (error) {
+      assert.equal(
+        error.message,
+        'Returned error: VM Exception while processing transaction: revert invalid royalty payout address'
+      );
+    }
+  });
+
+  it('test batch mint successfully in 1 transaction', async function () {
+    let editionNumber1 = 3;
+    let editionNumber2 = 4;
+
+    // Mint to 0xb824edfc5dced3ac86b6f5816763a35c2ba66fa2 and transfer to 0xD588e5EC7900C881Cec1843f2EbC73601D75e584
+    await this.exhibition.batchMint([
+      [this.artworkID, editionNumber1, accounts[0], accounts[0], 'test1'],
+      [
+        this.artworkID,
+        editionNumber2,
+        '0xb824edfc5dced3ac86b6f5816763a35c2ba66fa2',
+        accounts[1],
+        'test2',
+      ],
+    ]);
+
+    let editionID1 = BigInt(this.artworkID) + BigInt(editionNumber1);
+    let ownerOfEdition1 = await this.exhibition.ownerOf(editionID1.toString());
+    assert.equal(ownerOfEdition1.toLowerCase(), accounts[0].toLowerCase());
+
+    let editionID2 = BigInt(this.artworkID) + BigInt(editionNumber2);
+    let ownerOfEdition2 = await this.exhibition.ownerOf(editionID2.toString());
+    assert.equal(ownerOfEdition2.toLowerCase(), accounts[1].toLowerCase());
+  });
+
+  it('test batch transfer artworks successfully in 1 transaction', async function () {
+    let editionNumber = 5;
+
+    // Mint to 0xb824edfc5dced3ac86b6f5816763a35c2ba66fa2 and transfer to 0xD588e5EC7900C881Cec1843f2EbC73601D75e584
+    await this.exhibition.batchMint([
+      [
+        this.artworkID,
+        editionNumber,
+        '0xb824edfc5dced3ac86b6f5816763a35c2ba66fa2',
+        accounts[1],
+        'test',
+      ],
+    ]);
+
+    let editionID = BigInt(this.artworkID) + BigInt(editionNumber);
+
+    let expiryTime = (new Date().getTime() / 1000 + 300).toFixed(0);
+
+    var instrucmentCode = web3.eth.abi.encodeParameters(
+      ['address', 'address', 'uint256', 'uint256'],
+      [
+        accounts[1],
+        '0x487ba00d91015dcc905bb93b528c12a05fbc7a4f',
+        editionID.toString(),
+        expiryTime,
+      ]
+    );
+    var hash = web3.utils.keccak256(instrucmentCode);
+    var sig = await web3.eth.sign(hash, accounts[1]);
+
+    sig = sig.substr(2);
+    r = '0x' + sig.slice(0, 64);
+    s = '0x' + sig.slice(64, 128);
+    v = '0x' + sig.slice(128, 130);
+
+    // Transfer item to 0x487ba00d91015dcc905bb93b528c12a05fbc7a4f
+    let transferredResult = await this.exhibition.authorizedTransfer([
+      [
+        accounts[1],
+        '0x487ba00d91015dcc905bb93b528c12a05fbc7a4f',
+        editionID.toString(),
+        expiryTime,
+        r,
+        s,
+        web3.utils.toDecimal(v) + 27, // magic 27
+      ],
+    ]);
+
+    let ownerOfEdition = await this.exhibition.ownerOf(editionID.toString());
+    assert.equal(
+      ownerOfEdition.toLowerCase(),
+      '0x487ba00d91015dcc905bb93b528c12a05fbc7a4f'.toLowerCase()
+    );
+  });
+
+  it('fail to batch transfer out of recv window', async function () {
+    let editionNumber = 6;
+
+    // Mint to 0xb824edfc5dced3ac86b6f5816763a35c2ba66fa2 and transfer to 0xD588e5EC7900C881Cec1843f2EbC73601D75e584
+    await this.exhibition.batchMint([
+      [
+        this.artworkID,
+        editionNumber,
+        '0xb824edfc5dced3ac86b6f5816763a35c2ba66fa2',
+        accounts[1],
+        'test6',
+      ],
+    ]);
+
+    let editionID = BigInt(this.artworkID) + BigInt(editionNumber);
+
+    let expiryTime = (new Date().getTime() / 1000 - 5).toFixed(0);
+
+    try {
+      // Transfer item to 0x487ba00d91015dcc905bb93b528c12a05fbc7a4f
+      let transferredResult = await this.exhibition.authorizedTransfer([
+        [
+          accounts[1],
+          '0x487ba00d91015dcc905bb93b528c12a05fbc7a4f',
+          editionID.toString(),
+          expiryTime,
+          '0x4b1be9d4a91bf5f0462e96be0a67e738ac3ee2b191896c51b6b071f35c590563',
+          '0x5a3c40da5f67db32aa3e8026f55d3305bc40e025f9ccac5067ef47256bb49483',
+          '0x1b',
+        ],
+      ]);
+    } catch (error) {
+      assert.equal(
+        error.message,
+        'Returned error: VM Exception while processing transaction: revert FeralfileExhibitionV3: the transfer request is expired'
+      );
+    }
+  });
+
+  it('fail to batch transfer invalid signature', async function () {
+    let editionNumber = 7;
+
+    // Mint to 0xb824edfc5dced3ac86b6f5816763a35c2ba66fa2 and transfer to 0xD588e5EC7900C881Cec1843f2EbC73601D75e584
+    await this.exhibition.batchMint([
+      [
+        this.artworkID,
+        editionNumber,
+        '0xb824edfc5dced3ac86b6f5816763a35c2ba66fa2',
+        accounts[1],
+        'test7',
+      ],
+    ]);
+
+    let editionID = BigInt(this.artworkID) + BigInt(editionNumber);
+
+    let expiryTime = (new Date().getTime() / 1000 + 300).toFixed(0);
+
+    try {
+      // Transfer item to 0x487ba00d91015dcc905bb93b528c12a05fbc7a4f
+      let transferredResult = await this.exhibition.authorizedTransfer([
+        [
+          accounts[1],
+          '0x487ba00d91015dcc905bb93b528c12a05fbc7a4f',
+          editionID.toString(),
+          expiryTime,
+          '0x4b1be9d4a91bf5f0462e96be0a67e738ac3ee2b191896c51b6b071f35c590563',
+          '0x5a3c40da5f67db32aa3e8026f55d3305bc40e025f9ccac5067ef47256bb49483',
+          '0x1b',
+        ],
+      ]);
+    } catch (error) {
+      assert.equal(
+        error.message,
+        'Returned error: VM Exception while processing transaction: revert FeralfileExhibitionV3: the transfer request is not authorized'
+      );
+    }
+  });
+
+  it('test burn edition successfully', async function () {
+    let editionNumber = 8;
+
+    await this.exhibition.batchMint([
+      [this.artworkID, editionNumber, accounts[0], accounts[0], 'test8'],
+    ]);
+
+    let editionID = BigInt(this.artworkID) + BigInt(editionNumber);
+
+    let editionCountBeforeBurn = await this.exhibition.totalEditionOfArtwork(
+      this.artworkID
+    );
+    assert.equal(editionCountBeforeBurn.toNumber(), 7);
+
+    await this.exhibition.burnEditions([editionID]);
+    let editionCountAfterBurn = await this.exhibition.totalEditionOfArtwork(
+      this.artworkID
+    );
+    assert.equal(editionCountAfterBurn.toNumber(), 6);
+  });
+
+  it('test burn edition failed', async function () {
+    let editionNumber = 9;
+
+    await this.exhibition.batchMint([
+      [
+        this.artworkID,
+        editionNumber,
+        '0xb824edfc5dced3ac86b6f5816763a35c2ba66fa2',
+        accounts[1],
+        'test9',
+      ],
+    ]);
+
+    let editionID = BigInt(this.artworkID) + BigInt(editionNumber);
+
+    try {
+      let burnedResult = await this.exhibition.burnEditions([editionID]);
+    } catch (error) {
+      assert.equal(
+        error.message,
+        'Returned error: VM Exception while processing transaction: revert ERC721: caller is not token owner nor approved'
+      );
+    }
+  });
+});

--- a/test/feralfile_exhibition_v3_3_regression_v3_2.js
+++ b/test/feralfile_exhibition_v3_3_regression_v3_2.js
@@ -1,0 +1,139 @@
+const FeralfileExhibitionV3_3 = artifacts.require('FeralfileExhibitionV3_3');
+const MockOperatorFilterRegistry = artifacts.require('MockOperatorFilterRegistry');
+
+const axios = require('axios');
+
+const IPFS_GATEWAY_PREFIX = 'https://ipfs.bitmark.com/ipfs/';
+
+const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
+
+const ALLOWED_EXCHANGE = '0x2de783974f53AC98b16332f943431df0FD66C9E4';
+
+contract('FeralfileExhibitionV3_3->V3_2_regression', async (accounts) => {
+  before(async function () {
+    this.operatorFilterRegistry = await MockOperatorFilterRegistry.new(ALLOWED_EXCHANGE)
+    this.testThumbnailCid = "QmV68mphFwMraCE9J6KpQc89Sz8ppvJx5CP6XFruhGQrX8" // AKG test IPFS thumbnail CID
+    this.testArtworkCid = "QmTn3PfHHvoDHKawTPXutqxAk2k8ynFK9cZfsSwggryjkX" // AKG test IPFS artwork CID
+
+    this.exhibition = await FeralfileExhibitionV3_3.new(
+      'Feral File V3_2 Test 002',
+      'FFV3',
+      1000,
+      '0x8fd310de32848798eB64Bd88f9C5656Eea32415e',
+      'https://ipfs.bitmark.com/ipfs/QmaptARVxNSP36PQai5oiCPqbrATvpydcJ8SPx6T6Yp1CZ',
+      IPFS_GATEWAY_PREFIX,
+      true,
+      true
+    );
+
+    await this.exhibition.updateOperatorFilterRegistry(this.operatorFilterRegistry.address)
+  });
+
+  it('can register artwork', async function () {
+    let r = await this.exhibition.createArtworks([
+      ['TestArtwork', 'TestUser', 'TestArtwork', 10, 2, 1],
+    ]);
+    this.artworkID = r.logs[0].args.artworkID;
+
+    let artwork = await this.exhibition.artworks(this.artworkID);
+    assert.equal(artwork.title, 'TestArtwork');
+
+    let artworkEditions = await this.exhibition.totalEditionOfArtwork(
+      this.artworkID
+    );
+    assert.equal(artworkEditions, 0);
+  });
+
+  it('test batch mint 1 artwork', async function () {
+    let editionIndex0 = 0;
+    let editionIndex1 = 1;
+    let editionIndex2 = 2;
+    let editionIndex3 = 3;
+
+    await this.exhibition.batchMint([
+      [this.artworkID, editionIndex0, accounts[0], accounts[0], 'test0'],
+      [this.artworkID, editionIndex1, accounts[0], accounts[0], 'test1'],
+      [this.artworkID, editionIndex2, accounts[0], accounts[0], 'test2'],
+      [this.artworkID, editionIndex3, accounts[0], accounts[0], 'test3'],
+    ]);
+
+    let account0 = accounts[0].toLowerCase()
+
+    this.editionID0 = (BigInt(this.artworkID) + BigInt(editionIndex0)).toString();
+    let ownerOfEdition0 = await this.exhibition.ownerOf(this.editionID0);
+    assert.equal(ownerOfEdition0.toLowerCase(), account0);
+
+    this.editionID1 = (BigInt(this.artworkID) + BigInt(editionIndex1)).toString();
+    let ownerOfEdition1 = await this.exhibition.ownerOf(this.editionID1);
+    assert.equal(ownerOfEdition1.toLowerCase(), account0);
+
+    this.editionID2 = (BigInt(this.artworkID) + BigInt(editionIndex2)).toString();
+    let ownerOfEdition2 = await this.exhibition.ownerOf(this.editionID2);
+    assert.equal(ownerOfEdition2.toLowerCase(), account0);
+
+    this.editionID3 = (BigInt(this.artworkID) + BigInt(editionIndex3)).toString();
+    let ownerOfEdition3 = await this.exhibition.ownerOf(this.editionID3);
+    assert.equal(ownerOfEdition3.toLowerCase(), account0);
+  })
+
+  it('can not approve an filtered exchange', async function () {
+    let onError = false;
+    try {
+      await this.exhibition.approve(this.operatorFilterRegistry.address, this.editionID0)
+    } catch (error) {
+      onError = true
+      assert.equal(
+        error.message,
+        'Returned error: VM Exception while processing transaction: revert operator is not allowed'
+      );
+    }
+    assert.equal(onError, true)
+    let addr = await this.exhibition.getApproved(this.editionID0)
+    assert.equal(addr, ZERO_ADDRESS)
+  })
+
+  it('can approve the allowed exchange', async function () {
+    await this.exhibition.approve(ALLOWED_EXCHANGE, this.editionID0)
+    let addr = await this.exhibition.getApproved(this.editionID0)
+    assert.equal(addr, ALLOWED_EXCHANGE)
+  })
+
+
+  it('can not transfer before approve', async function () {
+    let onError = false;
+    try {
+      await this.exhibition.safeTransferFrom(accounts[0], accounts[1], this.editionID1, {
+        "from": accounts[1]
+      })
+    } catch (error) {
+      onError = true
+      assert.equal(
+        error.message,
+        'Returned error: VM Exception while processing transaction: revert ERC721: caller is not token owner nor approved'
+      );
+    }
+    assert.equal(onError, true)
+  })
+
+  it('can approve the regular address and transfer', async function () {
+    let account1 = accounts[1]
+    await this.exhibition.approve(account1, this.editionID1)
+    let addr = await this.exhibition.getApproved(this.editionID1)
+    assert.equal(addr, account1)
+    await this.exhibition.safeTransferFrom(accounts[0], account1, this.editionID1, {
+      "from": account1
+    })
+
+    let ownerOfEdition1 = await this.exhibition.ownerOf(this.editionID1);
+    assert.equal(ownerOfEdition1, account1);
+  })
+
+  it('can approve when unset the registry', async function () {
+    await this.exhibition.updateOperatorFilterRegistry(ZERO_ADDRESS)
+    let addressBefore = await this.exhibition.getApproved(this.editionID2)
+    assert.equal(addressBefore, ZERO_ADDRESS)
+    await this.exhibition.approve(this.operatorFilterRegistry.address, this.editionID2)
+    let addressAfter = await this.exhibition.getApproved(this.editionID2)
+    assert.equal(addressAfter, this.operatorFilterRegistry.address)
+  })
+});


### PR DESCRIPTION
Add a FFV3_3 for AKG which merges both AKG feature from V3_1 and OperatorRegistry from V3_2.

Block: 
- This PR requires #12 to be merged first. After that we have to change the base from `feature/support-operator-filter-registry` to `main`

Changes:
- [x] new contract inherit from FeralFileExhibitionV3_2
- [x] update test cases and provide regression test for both V3 and V3_2