### PR TITLE
Fix incorrect index referencing for burn function

### DIFF
--- a/contracts/FeralfileArtworkV3.sol
+++ b/contracts/FeralfileArtworkV3.sol
@@ -476,14 +476,13 @@ contract FeralfileExhibitionV3 is ERC721Enumerable, Authorizable, IERC2981 {
             "FeralfileExhibitionV3: no editions in this artwork of allArtworkEditions"
         );
 
-        uint256 lastEditionIndex = artworkEditions_.length - 1;
         uint256 lastEditionID = artworkEditions_[artworkEditions_.length - 1];
 
         // Swap between the last token and the to-delete token and pop up the last token
         artworkEditions_[artworkEditionIndex.index] = lastEditionID;
-        artworkEditions_[lastEditionIndex] = artworkEditionIndex.index;
         artworkEditions_.pop();
-
+        allArtworkEditionsIndex[lastEditionID].index = artworkEditionIndex
+            .index;
         delete allArtworkEditionsIndex[editionID];
     }
 

--- a/test/feralfile_exhibition_v3.js
+++ b/test/feralfile_exhibition_v3.js
@@ -8,7 +8,7 @@ const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
 
 const originArtworkCID = 'QmQPeNsJPyVWPFDVHb77w8G42Fvo15z4bG2X8D2GhfbSXc';
 
-contract('FeralfileExhibitionV3', async (accounts) => {
+contract('FeralfileExhibitionV3_0', async (accounts) => {
   before(async function () {
     this.exhibition = await FeralfileExhibitionV3.new(
       'Feral File V3 Test 001',
@@ -354,20 +354,32 @@ contract('FeralfileExhibitionV3', async (accounts) => {
   });
 
   it('test burn edition successfully', async function () {
-    let editionNumber = 8;
+    let editionNumber1 = 8;
+    let editionNumber2 = 9;
+    let editionNumber3 = 10;
 
     await this.exhibition.batchMint([
-      [this.artworkID, editionNumber, accounts[0], accounts[0], 'test8'],
+      [this.artworkID, editionNumber1, accounts[0], accounts[0], 'test8'],
+    ]);
+    await this.exhibition.batchMint([
+      [this.artworkID, editionNumber2, accounts[0], accounts[0], 'test9'],
+    ]);
+    await this.exhibition.batchMint([
+      [this.artworkID, editionNumber3, accounts[0], accounts[0], 'test10'],
     ]);
 
-    let editionID = BigInt(this.artworkID) + BigInt(editionNumber);
+    let editionID1 = BigInt(this.artworkID) + BigInt(editionNumber1);
+    let editionID2 = BigInt(this.artworkID) + BigInt(editionNumber2);
+    let editionID3 = BigInt(this.artworkID) + BigInt(editionNumber3);
 
     let editionCountBeforeBurn = await this.exhibition.totalEditionOfArtwork(
       this.artworkID
     );
-    assert.equal(editionCountBeforeBurn.toNumber(), 7);
+    assert.equal(editionCountBeforeBurn.toNumber(), 9);
 
-    await this.exhibition.burnEditions([editionID]);
+    await this.exhibition.burnEditions([editionID1]);
+    await this.exhibition.burnEditions([editionID2]);
+    await this.exhibition.burnEditions([editionID3]);
     let editionCountAfterBurn = await this.exhibition.totalEditionOfArtwork(
       this.artworkID
     );
@@ -375,7 +387,7 @@ contract('FeralfileExhibitionV3', async (accounts) => {
   });
 
   it('test burn edition failed', async function () {
-    let editionNumber = 9;
+    let editionNumber = 11;
 
     await this.exhibition.batchMint([
       [


### PR DESCRIPTION
**Description**

The missing update of index value in `allArtworkEditionsIndex` for last item causes the incorrect referencing of `artworkEditions_` for burn function. This PR is aim to solve it.

**Task Done**

- [x] fix the bug
- [x] update test cases.